### PR TITLE
namespace normalization refactoring

### DIFF
--- a/entityframeworkrepository.cache/AbstractCacheProvider.cs
+++ b/entityframeworkrepository.cache/AbstractCacheProvider.cs
@@ -16,6 +16,5 @@ namespace entityframeworkrepository.cache
         public abstract bool Set(ICacheKey cacheKey, object value, ICachePolicy cachePolicy);
         public abstract object GetOrAdd(ICacheKey cacheKey, Func<ICacheKey, object> valueFactory, ICachePolicy cachePolicy);
         public abstract Task<object> GetOrAddAsync(ICacheKey cacheKey, Func<ICacheKey, Task<object>> valueFactory, ICachePolicy cachePolicy);
-      
     }
 }

--- a/entityframeworkrepository.cache/CacheKey.cs
+++ b/entityframeworkrepository.cache/CacheKey.cs
@@ -27,12 +27,10 @@ namespace entityframeworkrepository.cache
         /// <param name="tags">The tags for the cache item.</param>
         public CacheKey(string key, IEnumerable<string> tags)
         {
-            if (key == null)
-                throw new ArgumentNullException("key");
             if (tags == null)
-                throw new ArgumentNullException("tags");
+                throw new ArgumentNullException(nameof(tags));
 
-            _key = key;
+            _key = key ?? throw new ArgumentNullException(nameof(key));
 
             var cacheTags = tags.Select(k => new CacheTag(k));
             _tags = new HashSet<ICacheTag>(cacheTags);

--- a/entityframeworkrepository.cache/CacheManager.cs
+++ b/entityframeworkrepository.cache/CacheManager.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using entityframeworkrepository.core;
 
 namespace entityframeworkrepository.cache
 {
@@ -27,7 +28,11 @@ namespace entityframeworkrepository.cache
     /// </example>
     public class CacheManager
     {
-        private static readonly Lazy<CacheManager> _current = new Lazy<CacheManager>(() => new CacheManager());
+        private static readonly Lazy<CacheManager> @current = new Lazy<CacheManager>(() => new CacheManager());
+
+        public CacheManager()
+        {
+        }
 
         /// <summary>
         /// Gets the current singleton instance of <see cref="CacheManager"/>.
@@ -35,7 +40,7 @@ namespace entityframeworkrepository.cache
         /// <value>The current singleton instance.</value>
         public static CacheManager Current
         {
-            get { return _current.Value; }
+            get { return @current.Value; }
         }
 
         /// <summary>

--- a/entityframeworkrepository.cache/CachePolicy.cs
+++ b/entityframeworkrepository.cache/CachePolicy.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Runtime.Caching;
 using System.Text;
 
+
 namespace entityframeworkrepository.cache
 {
     /// <summary>

--- a/entityframeworkrepository.cache/Extentions/CacheExtensions.cs
+++ b/entityframeworkrepository.cache/Extentions/CacheExtensions.cs
@@ -5,7 +5,6 @@ using System.Data.Entity;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
-using System.Runtime.Remoting.Channels;
 using entityframeworkrepository.cache.Query;
 
 namespace entityframeworkrepository.cache.Extentions
@@ -88,6 +87,7 @@ namespace entityframeworkrepository.cache.Extentions
         public static TEntity FromCacheFirstOrDefault<TEntity>(this IQueryable<TEntity> query, CachePolicy cachePolicy = null, IEnumerable<string> tags = null)
             where TEntity : class
         {
+            // ReSharper disable once PossibleUnintendedQueryableAsEnumerable
             return query.Take(1).FromCache(cachePolicy, tags).FirstOrDefault();
         }
 

--- a/entityframeworkrepository.cache/MemoryCacheProvider.cs
+++ b/entityframeworkrepository.cache/MemoryCacheProvider.cs
@@ -5,6 +5,7 @@ using System.Runtime.Caching;
 using System.Runtime.Caching.Generic;
 using System.Threading.Tasks;
 
+
 namespace entityframeworkrepository.cache
 {
     /// <summary>
@@ -89,7 +90,7 @@ namespace entityframeworkrepository.cache
         /// The value for the key. This will be either the existing value for the key if the key is already in the cache,
         /// or the new value for the key as returned by <paramref name="valueFactory"/> if the key was not in the cache.
         /// </returns>
-        public async override Task<object> GetOrAddAsync(ICacheKey cacheKey, Func<ICacheKey, Task<object>> valueFactory, ICachePolicy cachePolicy)
+        public override async Task<object> GetOrAddAsync(ICacheKey cacheKey, Func<ICacheKey, Task<object>> valueFactory, ICachePolicy cachePolicy)
         {
             var key = GetKey(cacheKey);
             var cachedResult = MemoryCache.Default.Get(key);

--- a/entityframeworkrepository.cache/Query/LocalCollectionExpander.cs
+++ b/entityframeworkrepository.cache/Query/LocalCollectionExpander.cs
@@ -9,7 +9,7 @@ namespace entityframeworkrepository.cache.Query
     /// <summary>
     /// Enables cache key support for local collection values.
     /// </summary>
-    internal class LocalCollectionExpander : ExpressionVisitor
+    internal partial class LocalCollectionExpander : ExpressionVisitor
     {
         public static Expression Rewrite(Expression expression)
         {
@@ -57,26 +57,6 @@ namespace entityframeworkrepository.cache.Query
             var printer = Activator.CreateInstance(printerType, value);
 
             return Expression.Constant(printer);
-        }
-
-        /// <summary>
-        /// Overrides ToString to print each element of a collection.
-        /// </summary>
-        /// <remarks>
-        /// Inherits List in order to support List.Contains instance method as well
-        /// as standard Enumerable.Contains/Any extension methods.
-        /// </remarks>
-        class Printer<T> : List<T>
-        {
-            public Printer(IEnumerable collection)
-            {
-                this.AddRange(collection.Cast<T>());
-            }
-
-            public override string ToString()
-            {
-                return "{" + this.ToConcatenatedString(t => t.ToString(), "|") + "}";
-            }
         }
     }
 }

--- a/entityframeworkrepository.cache/Query/Printer.cs
+++ b/entityframeworkrepository.cache/Query/Printer.cs
@@ -1,0 +1,29 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace entityframeworkrepository.cache.Query
+{
+    internal partial class LocalCollectionExpander
+    {
+        /// <summary>
+        /// Overrides ToString to print each element of a collection.
+        /// </summary>
+        /// <remarks>
+        /// Inherits List in order to support List.Contains instance method as well
+        /// as standard Enumerable.Contains/Any extension methods.
+        /// </remarks>
+        class Printer<T> : List<T>
+        {
+            public Printer(IEnumerable collection)
+            {
+                this.AddRange(collection.Cast<T>());
+            }
+
+            public override string ToString()
+            {
+                return "{" + this.ToConcatenatedString(t => t.ToString(), "|") + "}";
+            }
+        }
+    }
+}

--- a/entityframeworkrepository.cache/entityframeworkrepository.cache.csproj
+++ b/entityframeworkrepository.cache/entityframeworkrepository.cache.csproj
@@ -66,6 +66,7 @@
     <Compile Include="Query\Evaluator.cs" />
     <Compile Include="Query\LocalCollectionExpander.cs" />
     <Compile Include="Query\Nominator.cs" />
+    <Compile Include="Query\Printer.cs" />
     <Compile Include="Query\QueryCache.cs" />
     <Compile Include="Query\SubtreeEvaluator.cs" />
     <Compile Include="Query\Utility.cs" />

--- a/entityframeworkrepository.core/cache/CacheExpirationMode.cs
+++ b/entityframeworkrepository.core/cache/CacheExpirationMode.cs
@@ -1,5 +1,3 @@
-using System;
-
 namespace entityframeworkrepository.cache
 {
     /// <summary>

--- a/entityframeworkrepository.core/cache/ICachePolicy.cs
+++ b/entityframeworkrepository.core/cache/ICachePolicy.cs
@@ -1,6 +1,6 @@
 ﻿using System;
-// ReSharper disable CheckNamespace
 
+// ReSharper disable CheckNamespace
 namespace entityframeworkrepository.cache
 {
     public interface ICachePolicy

--- a/entityframeworkrepository.core/cache/ICacheTag.cs
+++ b/entityframeworkrepository.core/cache/ICacheTag.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-// ReSharper disable CheckNamespace
+
 
 namespace entityframeworkrepository.cache
 {

--- a/entityframeworkrepository.core/repository/ICacheRepository.cs
+++ b/entityframeworkrepository.core/repository/ICacheRepository.cs
@@ -1,8 +1,7 @@
-﻿using entityframeworkrepository.cache;
-using entityframeworkrepository.core;
+﻿
 using entityframeworkrepository.core.query;
 
-namespace entityframeworkrepository.core.repository
+namespace entityframeworkrepository.repository.cache
 {
     /// <summary>
     /// ICacheRepository<typeparam name="T"> Entity </typeparam>

--- a/entityframeworkrepository.core/repository/IGenericCacheRepository.cs
+++ b/entityframeworkrepository.core/repository/IGenericCacheRepository.cs
@@ -1,4 +1,4 @@
-namespace entityframeworkrepository.core.repository
+namespace entityframeworkrepository.repository.cache
 {
     /// <summary>
     /// IGenericCacheRepository

--- a/entityframeworkrepository.core/repository/IGenericDataRepository.cs
+++ b/entityframeworkrepository.core/repository/IGenericDataRepository.cs
@@ -4,7 +4,8 @@ using System.Linq.Expressions;
 using entityframeworkrepository.core.entity;
 using entityframeworkrepository.core.query;
 
-namespace entityframeworkrepository.core.repository
+// ReSharper disable once CheckNamespace
+namespace entityframeworkrepository.repository
 {
     public interface IGenericDataRepository<T>: IDbQuery<T> where T : class
     {

--- a/entityframeworkrepository.core/service/EntityService.cs
+++ b/entityframeworkrepository.core/service/EntityService.cs
@@ -1,7 +1,8 @@
 using System;
 using System.Collections.Generic;
+
 using entityframeworkrepository.core.entity;
-using entityframeworkrepository.core.repository;
+using entityframeworkrepository.repository;
 using entityframeworkrepository.core.unitofwork;
 
 namespace entityframeworkrepository.core.service

--- a/entityframeworkrepository.repository/GenericDataRepository.cs
+++ b/entityframeworkrepository.repository/GenericDataRepository.cs
@@ -6,10 +6,10 @@ using System.Data.Entity.Migrations;
 using System.Data.SqlClient;
 using System.Linq;
 using System.Linq.Expressions;
-using entityframeworkrepository.cache;
+
 using entityframeworkrepository.cache.Extentions;
 using entityframeworkrepository.core.entity;
-using entityframeworkrepository.core.repository;
+
 
 namespace entityframeworkrepository.repository
 {
@@ -28,7 +28,7 @@ namespace entityframeworkrepository.repository
         /// <param name="context"></param>
         public GenericDataRepository(DbContext context)
         {
-            if (context == null) throw new ArgumentNullException("@context");
+            if (context == null) throw new ArgumentNullException(nameof(context));
             _entities = context;
 
             _entities.Configuration.AutoDetectChangesEnabled = false;

--- a/entityframeworkrepository.repository/cache/AbstractGenericCacheRepository.cs
+++ b/entityframeworkrepository.repository/cache/AbstractGenericCacheRepository.cs
@@ -2,10 +2,9 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
-using entityframeworkrepository.core.entity;
-using entityframeworkrepository.core.repository;
 
-namespace entityframeworkrepository.repository
+
+namespace entityframeworkrepository.repository.cache
 {
     /// <summary>
     /// AbstractGenericCacheRepository<typeparam name="T">Entity</typeparam>

--- a/entityframeworkrepository.repository/cache/GenericCacheRepository.cs
+++ b/entityframeworkrepository.repository/cache/GenericCacheRepository.cs
@@ -7,9 +7,8 @@ using System.Linq;
 using System.Linq.Expressions;
 using entityframeworkrepository.cache;
 using entityframeworkrepository.cache.Extentions;
-using entityframeworkrepository.core.repository;
 
-namespace entityframeworkrepository.repository
+namespace entityframeworkrepository.repository.cache
 {
 
     /// <summary>
@@ -41,7 +40,7 @@ namespace entityframeworkrepository.repository
             }
             catch (SqlException ex)
             {
-                throw new EntityException(string.Format("{0} - {1}", typeof(T), ex.Message), ex);
+                throw new EntityException($"{typeof(T)} - {ex.Message}", ex);
             }
 
             return list;
@@ -60,7 +59,7 @@ namespace entityframeworkrepository.repository
             }
             catch (SqlException ex)
             {
-                throw new EntityException(string.Format("{0} - {1}", typeof(T), ex.Message), ex);
+                throw new EntityException($"{typeof(T)} - {ex.Message}", ex);
             }
 
             return list;
@@ -75,14 +74,15 @@ namespace entityframeworkrepository.repository
                 IQueryable<T> dbQuery = _entities.Set<T>();
 
                 //Apply eager loading
-                dbQuery = navigationProperties.Aggregate(dbQuery, (current, navigationProperty) => current.Include(navigationProperty));
+                dbQuery = navigationProperties.Aggregate(dbQuery, (current, navigationProperty) => 
+                                                                   current.Include(navigationProperty));
 
                 item = FromCache(ToQueryable(dbQuery)).FirstOrDefault(where);
 
             }
             catch (SqlException ex)
             {
-                throw new EntityException(string.Format("{0} - {1}", typeof(T), ex.Message), ex);
+                throw new EntityException($"{typeof(T)} - {ex.Message}", ex);
             }
 
             return item;

--- a/entityframeworkrepository.repository/entityframeworkrepository.repository.csproj
+++ b/entityframeworkrepository.repository/entityframeworkrepository.repository.csproj
@@ -56,8 +56,8 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="AbstractGenericCacheRepository.cs" />
-    <Compile Include="GenericCacheRepository.cs" />
+    <Compile Include="cache\AbstractGenericCacheRepository.cs" />
+    <Compile Include="cache\GenericCacheRepository.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="GenericDataRepository.cs" />
   </ItemGroup>

--- a/entityframeworkrepository.tests/EntityServicesTests.cs
+++ b/entityframeworkrepository.tests/EntityServicesTests.cs
@@ -5,10 +5,11 @@ using System.Text;
 using System.Threading.Tasks;
 using Castle.Core.Internal;
 using entityframeworkrepository.cache;
+
 using entityframeworkrepository.core.entity;
-using entityframeworkrepository.core.repository;
 using entityframeworkrepository.core.service;
 using entityframeworkrepository.core.unitofwork;
+
 using entityframeworkrepository.repository;
 using Moq;
 using Newtonsoft.Json;

--- a/entityframeworkrepository.tests/GenericDataRepositoryTests.cs
+++ b/entityframeworkrepository.tests/GenericDataRepositoryTests.cs
@@ -1,10 +1,11 @@
 ﻿using System;
 using System.Data.Entity;
 using System.Linq;
+
 using entityframeworkrepository.cache;
-using entityframeworkrepository.core.entity;
-using entityframeworkrepository.core.repository;
 using entityframeworkrepository.repository;
+using entityframeworkrepository.repository.cache;
+
 using NUnit.Framework;
 using NUnit.Framework.Internal;
 

--- a/entityframeworkrepository.webapp/App_Start/WebApiConfig.cs
+++ b/entityframeworkrepository.webapp/App_Start/WebApiConfig.cs
@@ -7,6 +7,7 @@ using System.Web.Http;
 using System.Web.Http.ModelBinding;
 using System.Web.Mvc;
 using entityframeworkrepository.cache;
+
 using Microsoft.Owin.Security.OAuth;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;

--- a/entityframeworkrepository.webapp/Controllers/DictionaryController.cs
+++ b/entityframeworkrepository.webapp/Controllers/DictionaryController.cs
@@ -6,7 +6,8 @@ using System.Net;
 using System.Net.Http;
 using System.Web.Http;
 using entityframeworkrepository.core.entity;
-using entityframeworkrepository.core.repository;
+using entityframeworkrepository.repository;
+using entityframeworkrepository.repository.cache;
 using entityframeworkrepository.webapp.Repository;
 using Dictionary = entityframeworkrepository.Dictionary;
 


### PR DESCRIPTION
made fixes for

- to be able to use caching by referencing "entityframeworkrepository.cache" for extention methods on IQueryable... 
- moved everything to proper named parts... "entityframeworkrepository.repository" etc...
- "entityframeworkrepository.repository.cache" for GenericCachingRepository